### PR TITLE
Put clock access inside pred_mutex

### DIFF
--- a/include/cm_executors/timer_manager.hpp
+++ b/include/cm_executors/timer_manager.hpp
@@ -94,6 +94,8 @@ public:
   void
   notify_one()
   {
+    std::unique_lock lock(pred_mutex_);
+
     if(clock_) {
       clock_->notify_one();
     }


### PR DESCRIPTION
Fixes https://github.com/cellumation/cm_executors/issues/5 by wrapping access to `clock_` inside of `pred_mutex_`. 