### PR TITLE
Fix deadlock from inverted lock order in `TestExecutors.dropSomeNodeWithTimer`

### DIFF
--- a/include/cm_executors/scheduler.hpp
+++ b/include/cm_executors/scheduler.hpp
@@ -117,10 +117,10 @@ protected:
     */
     void check_move_to_ready(std::unique_lock<std::mutex> & lock)
     {
-    if(lock.mutex() != &ready_mutex) {
-      throw std::runtime_error(
+      if(lock.mutex() != &ready_mutex) {
+        throw std::runtime_error(
           "this function must be called under the ready mutex!");
-    }
+      }
       if(not_ready) {
         return;
       }

--- a/include/cm_executors/scheduler.hpp
+++ b/include/cm_executors/scheduler.hpp
@@ -85,12 +85,13 @@ public:
 
     void mark_as_executed()
     {
-      std::lock_guard l(ready_mutex);
+      std::unique_lock l(ready_mutex);
       not_ready = false;
 
       if(!has_ready_entities()) {
         idle = true;
       } else {
+        l.unlock();
             // inform scheduler that we have more work
         scheduler.callback_group_ready(this);
       }
@@ -114,14 +115,20 @@ protected:
     *
     * Must be called with ready_mutex locked
     */
-    void check_move_to_ready()
+    void check_move_to_ready(std::unique_lock<std::mutex> & lock)
     {
+    if(lock.mutex() != &ready_mutex) {
+      throw std::runtime_error(
+          "this function must be called under the ready mutex!");
+    }
       if(not_ready) {
         return;
       }
 
       if(idle) {
+        lock.unlock();
         scheduler.callback_group_ready(this);
+        lock.lock();
         idle = false;
       }
     }

--- a/include/cm_executors/scheduler.hpp
+++ b/include/cm_executors/scheduler.hpp
@@ -126,7 +126,7 @@ protected:
       }
     }
 
-    void mark_as_skiped()
+    void mark_as_skipped()
     {
       if(!has_ready_entities()) {
         idle = true;

--- a/src/FirstInFirstOutScheduler.cpp
+++ b/src/FirstInFirstOutScheduler.cpp
@@ -135,7 +135,7 @@ get_next_ready_entity()
     return CBGScheduler::ExecutableEntity{exec_fun, this};
   }
 
-  mark_as_skiped();
+  mark_as_skipped();
 
   return std::nullopt;
 }
@@ -167,7 +167,7 @@ get_next_ready_entity(GlobalEventIdProvider::MonotonicId max_id)
     return CBGScheduler::ExecutableEntity{exec_fun, this};
   }
 
-  mark_as_skiped();
+  mark_as_skipped();
 
 //   RCUTILS_LOG_ERROR_NAMED("FirstInFirstOutCallbackGroupHandle",
 //   ("no ready_entities max id " + std::to_string(max_id)).c_str());

--- a/src/FirstInFirstOutScheduler.cpp
+++ b/src/FirstInFirstOutScheduler.cpp
@@ -22,14 +22,14 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
   const rclcpp::SubscriptionBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_ERROR_NAMED("FirstInFirstOutCallbackGroupHandle", "subscriber got data");
            for (size_t i = 0; i < nr_msg; i++) {
              ready_entities.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -37,14 +37,14 @@ std::function<void(std::function<void()> executed_callback)> FirstInFirstOutCall
 get_ready_callback_for_entity(const rclcpp::TimerBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](std::function<void()> executed_callback) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "TimerBase ready callback called");
 
            ready_entities.emplace_back(ReadyEntity::ReadyTimerWithExecutedCallback{weak_ptr,
                executed_callback});
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -52,7 +52,7 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
   const rclcpp::ClientBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "ClientBase ready callback called");
@@ -60,7 +60,7 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
              ready_entities.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -68,7 +68,7 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
   const rclcpp::ServiceBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "ServiceBase ready callback called");
@@ -76,7 +76,7 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
              ready_entities.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -85,7 +85,7 @@ std::function<void(size_t,
   const rclcpp::Waitable::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg, int event_type) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "Waitable ready callback called");
@@ -94,14 +94,14 @@ std::function<void(size_t,
                  event_type}));
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callback_for_entity(
   const CBGScheduler::CallbackEventType & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "CallbackEventType ready callback called");
@@ -109,7 +109,7 @@ std::function<void(size_t)> FirstInFirstOutCallbackGroupHandle::get_ready_callba
              ready_entities.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -118,7 +118,7 @@ get_next_ready_entity()
 {
 //     RCUTILS_LOG_ERROR_NAMED("FirstInFirstOutCallbackGroupHandle",
 //     "get_next_ready_entity called");
-  std::lock_guard l(ready_mutex);
+  std::unique_lock l(ready_mutex);
 
   while(!ready_entities.empty()) {
     auto & first = ready_entities.front();
@@ -143,7 +143,7 @@ get_next_ready_entity()
 std::optional<CBGScheduler::ExecutableEntity> FirstInFirstOutCallbackGroupHandle::
 get_next_ready_entity(GlobalEventIdProvider::MonotonicId max_id)
 {
-  std::lock_guard l(ready_mutex);
+  std::unique_lock l(ready_mutex);
 
   while(!ready_entities.empty()) {
     auto & first = ready_entities.front();

--- a/src/PriorityScheduler.cpp
+++ b/src/PriorityScheduler.cpp
@@ -185,7 +185,7 @@ std::optional<CBGScheduler::ExecutableEntity> PriorityCallbackGroupHandle::get_n
     return CBGScheduler::ExecutableEntity{exec_fun, this};
   }
 
-  mark_as_skiped();
+  mark_as_skipped();
 
   return std::nullopt;
 }
@@ -218,7 +218,7 @@ std::optional<CBGScheduler::ExecutableEntity> PriorityCallbackGroupHandle::get_n
     return CBGScheduler::ExecutableEntity{exec_fun, this};
   }
 
-  mark_as_skiped();
+  mark_as_skipped();
 
 //   RCUTILS_LOG_ERROR_NAMED("PriorityCallbackGroupHandle",
 //                           ("no ready_entities max id " +

--- a/src/PriorityScheduler.cpp
+++ b/src/PriorityScheduler.cpp
@@ -22,14 +22,14 @@ std::function<void(size_t)> PriorityCallbackGroupHandle::get_ready_callback_for_
   const rclcpp::SubscriptionBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //                 RCUTILS_LOG_ERROR_NAMED("rclcpp", "subscriber got data");
            for (size_t i = 0; i < nr_msg; i++) {
              ready_subscriptions.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -37,14 +37,14 @@ std::function<void(std::function<void()> executed_callback)> PriorityCallbackGro
 get_ready_callback_for_entity(const rclcpp::TimerBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](std::function<void()> executed_callback) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 //         RCUTILS_LOG_INFO_NAMED("FirstInFirstOutCallbackGroupHandle",
 //            "TimerBase ready callback called");
 
            ready_timers.emplace_back(ReadyEntity::ReadyTimerWithExecutedCallback{weak_ptr,
                executed_callback});
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -52,14 +52,14 @@ std::function<void(size_t)> PriorityCallbackGroupHandle::get_ready_callback_for_
   const rclcpp::ClientBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //                 RCUTILS_LOG_ERROR_NAMED("rclcpp", "subscriber got data");
            for (size_t i = 0; i < nr_msg; i++) {
              ready_clients.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -67,14 +67,14 @@ std::function<void(size_t)> PriorityCallbackGroupHandle::get_ready_callback_for_
   const rclcpp::ServiceBase::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //                 RCUTILS_LOG_ERROR_NAMED("rclcpp", "subscriber got data");
            for (size_t i = 0; i < nr_msg; i++) {
              ready_services.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -83,7 +83,7 @@ std::function<void(size_t,
   const rclcpp::Waitable::WeakPtr & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg, int event_type) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //         RCUTILS_LOG_ERROR_NAMED("rclcpp", "Waitable got data");
            for (size_t i = 0; i < nr_msg; i++) {
@@ -91,21 +91,21 @@ std::function<void(size_t,
                  event_type}));
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 std::function<void(size_t)> PriorityCallbackGroupHandle::get_ready_callback_for_entity(
   const CBGScheduler::CallbackEventType & entity)
 {
   return [weak_ptr = entity, this](size_t nr_msg) {
-           std::lock_guard l(ready_mutex);
+           std::unique_lock l(ready_mutex);
 
 //                 RCUTILS_LOG_ERROR_NAMED("rclcpp", "subscriber got data");
            for (size_t i = 0; i < nr_msg; i++) {
              ready_calls.emplace_back(weak_ptr);
            }
 
-           check_move_to_ready();
+           check_move_to_ready(l);
          };
 }
 
@@ -167,7 +167,7 @@ std::optional<CBGScheduler::ExecutableEntity> PriorityCallbackGroupHandle::get_n
   std::deque<ReadyEntity> & queue)
 {
 //     RCUTILS_LOG_ERROR_NAMED("PriorityCallbackGroupHandle", "get_next_ready_entity called");
-  std::lock_guard l(ready_mutex);
+  std::unique_lock l(ready_mutex);
 
   while(!queue.empty()) {
     auto & first = queue.front();
@@ -193,7 +193,7 @@ std::optional<CBGScheduler::ExecutableEntity> PriorityCallbackGroupHandle::get_n
 std::optional<CBGScheduler::ExecutableEntity> PriorityCallbackGroupHandle::get_next_ready_entity(
   GlobalEventIdProvider::MonotonicId max_id, std::deque<ReadyEntity> & queue)
 {
-  std::lock_guard l(ready_mutex);
+  std::unique_lock l(ready_mutex);
 
   while(!queue.empty()) {
     auto & first = queue.front();

--- a/test/executors/test_executors.cpp
+++ b/test/executors/test_executors.cpp
@@ -950,6 +950,233 @@ TYPED_TEST(TestExecutors, testRaceConditionAddNode)
   }
 }
 
+
+TYPED_TEST(TestExecutors, dropSomeNodeWithTimer)
+{
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+
+  auto node1 = std::make_shared<rclcpp::Node>("test_node_1");
+  auto node2 = std::make_shared<rclcpp::Node>("test_node_2");
+
+  bool timer1_works = false;
+  bool timer2_works = false;
+
+  auto timer1 = node1->create_timer(std::chrono::milliseconds(10), [&timer1_works]() {
+        timer1_works = true;
+  });
+  auto timer2 = node2->create_timer(std::chrono::milliseconds(10), [&timer2_works]() {
+        timer2_works = true;
+  });
+
+  executor.add_node(node1);
+  executor.add_node(node2);
+
+  // first let's make sure that both timers work
+  auto max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!timer1_works || !timer2_works) {
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  // delete node 1.
+  node1 = nullptr;
+
+  timer2_works = false;
+  max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!timer2_works) {
+    // let the executor pick up the node and the timer
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  ASSERT_TRUE(timer2_works);
+}
+
+
+TYPED_TEST(TestExecutors, dropSomeSubscription)
+{
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+
+  bool sub1_works = false;
+  bool sub2_works = false;
+
+  auto sub1 = node->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub1_works](const test_msgs::msg::Empty &) {
+        sub1_works = true;
+  });
+  auto sub2 = node->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub2_works](const test_msgs::msg::Empty &) {
+        sub2_works = true;
+  });
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("/test_drop", 10);
+
+  executor.add_node(node);
+
+  // first let's make sure that both timers work
+  auto max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!sub1_works || !sub2_works) {
+    pub->publish(test_msgs::msg::Empty());
+
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  // delete subscription 2. Note, the executor uses an unordered map internally, to order
+  // the entities added to the rcl waitset therefore the order is kind of undefined,
+  // and this test may be flaky. In case it triggers, something is most likely
+  // really broken.
+  sub2.reset();
+
+  sub1_works = false;
+  sub2_works = false;
+  max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!sub1_works && !sub2_works) {
+    pub->publish(test_msgs::msg::Empty());
+
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  ASSERT_TRUE(sub1_works || sub2_works);
+}
+
+TYPED_TEST(TestExecutors, dropSomeNodesWithSubscription)
+{
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto node1 = std::make_shared<rclcpp::Node>("test_node_1");
+  auto node2 = std::make_shared<rclcpp::Node>("test_node_2");
+
+  bool sub1_works = false;
+  bool sub2_works = false;
+
+  auto sub1 = node1->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub1_works](const test_msgs::msg::Empty &) {
+        sub1_works = true;
+  });
+  auto sub2 = node2->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub2_works](const test_msgs::msg::Empty &) {
+        sub2_works = true;
+  });
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("/test_drop", 10);
+
+  executor.add_node(node);
+  executor.add_node(node1);
+  executor.add_node(node2);
+
+  // first let's make sure that both subscribers work
+  auto max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!sub1_works || !sub2_works) {
+    pub->publish(test_msgs::msg::Empty());
+
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  // delete node 2.
+  node2 = nullptr;
+
+  sub1_works = false;
+  max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while(!sub1_works) {
+    pub->publish(test_msgs::msg::Empty());
+
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  ASSERT_TRUE(sub1_works);
+}
+
+TYPED_TEST(TestExecutors, dropSubscriptionDuringCallback)
+{
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+
+
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+
+  bool sub1_works = false;
+  bool sub2_works = false;
+
+  auto cbg = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, true);
+  rclcpp::SubscriptionOptions sub_ops;
+  sub_ops.callback_group = cbg;
+
+  rclcpp::SubscriptionBase::SharedPtr sub1;
+  rclcpp::SubscriptionBase::SharedPtr sub2;
+
+  // Note, the executor uses an unordered map internally, to order
+  // the entities added to the rcl waitset therefore the order of the subscriptions
+  // is kind of undefined. Therefore each sub deletes the other one.
+  sub1 = node->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub1_works, &sub2](const test_msgs::msg::Empty &) {
+        sub1_works = true;
+        // delete the other subscriber
+        sub2.reset();
+  }, sub_ops);
+  sub2 = node->create_subscription<test_msgs::msg::Empty>("/test_drop", 10,
+      [&sub2_works, &sub1](const test_msgs::msg::Empty &) {
+        sub2_works = true;
+        // delete the other subscriber
+        sub1.reset();
+  }, sub_ops);
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("/test_drop", 10);
+
+  // wait for both subs to be connected
+  auto max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(1500);
+  while ((sub1->get_publisher_count() == 0) || (sub2->get_publisher_count() == 0)) {
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  executor.add_node(node);
+
+  // publish some messages, until one subscriber fired. As both subscribers are
+  // connected to the same topic, they should fire in the same wait.
+  max_end_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+  while (!sub1_works && !sub2_works) {
+    pub->publish(test_msgs::msg::Empty());
+
+    // let the executor pick up the node and the timers
+    executor.spin_all(std::chrono::milliseconds(10));
+
+    const auto cur_time = std::chrono::steady_clock::now();
+    ASSERT_LT(cur_time, max_end_time);
+  }
+
+  // only one subscriber must have worked, as the other
+  // one was deleted during the callback
+  ASSERT_TRUE(!sub1_works || !sub2_works);
+}
+
+
 // Check spin_until_future_complete with node base pointer (instantiates its own executor)
 TEST(TestExecutors, testSpinUntilFutureCompleteNodeBasePtr)
 {


### PR DESCRIPTION
I started putting together an rclcpp branch which adds the EventsCBGExecutor and runs it against existing tests, and I found that there were upstream tests added to `test_executors.cpp` which were missing here. 

When running with those tests, I discovered a deadlock on `TYPED_TEST(TestExecutors, dropSomeNodeWithTimer)`. After doing some digging with GDB, I found that the lock order of `ready_mutex` and `ready_callback_groups_mutex` is inverted depending on whether a new ready entity is being acquired in the main thread, or if a timer callback is being triggered. 

I've added some backtraces from my rclcpp branch which are reproducible in this repo with the added `dropSomeNodeWithTimer` test.

```cpp

(gdb) blocked

********************************************************************************
Displaying blocking threads using 'blocked' command
Thread: 48802 waits for thread: 46656 AND DEADLOCKED
Thread: 46656 waits for thread: 48802 AND DEADLOCKED
********************************************************************************
```

when a timer is triggered
`FirstInFirstOutCallbackGroupHandle::get_ready_callback_for_entity` acquires `ready_mutex`
then`Scheduler::callback_group_ready` tries to acquire `ready_callback_groups_mutex `
<details>
<summary>GDB backtrace: timer thread</summary>

```cpp
(gdb) thread 2145
[Switching to thread 2145 (Thread 0x7fffddffb6c0 (LWP 48802))]
#0  futex_wait (private=0, expected=2, futex_word=0x5555562e2168) at ../sysdeps/nptl/futex-internal.h:146
146     in ../sysdeps/nptl/futex-internal.h
(gdb) bt full
#0  futex_wait (private=0, expected=2, futex_word=0x5555562e2168) at ../sysdeps/nptl/futex-internal.h:146
        __ret = -512
        err = <optimized out>
        err = <optimized out>
        __ret = <optimized out>
        resultvar = <optimized out>
        __arg4 = <optimized out>
        __arg3 = <optimized out>
        __arg2 = <optimized out>
        __arg1 = <optimized out>
        _a4 = <optimized out>
        _a3 = <optimized out>
        _a2 = <optimized out>
        _a1 = <optimized out>
#1  __GI___lll_lock_wait (futex=futex@entry=0x5555562e2168, private=0) at ./nptl/lowlevellock.c:49
No locals.
#2  0x00007ffff6927101 in lll_mutex_lock_optimized (mutex=0x5555562e2168) at ./nptl/pthread_mutex_lock.c:48
        __futex = 0x5555562e2168
        private = <optimized out>
        private = <optimized out>
        __futex = <optimized out>
#3  ___pthread_mutex_lock (mutex=0x5555562e2168) at ./nptl/pthread_mutex_lock.c:93
        type = <optimized out>
        __PRETTY_FUNCTION__ = "___pthread_mutex_lock"
        id = <optimized out>
#4  0x0000555555ce8b75 in __gthread_mutex_lock (__mutex=0x5555562e2168)
    at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:749
No locals.
#5  0x0000555555cec88c in std::mutex::lock (this=0x5555562e2168) at /usr/include/c++/13/bits/std_mutex.h:113
        __e = 21845
#6  0x0000555555cf44a2 in std::lock_guard<std::mutex>::lock_guard (this=0x7fffddffa2e0, __m=...)
    at /usr/include/c++/13/bits/std_mutex.h:249
No locals.
#7  0x00007ffff7974cbb in rclcpp::executors::CBGScheduler::callback_group_ready (this=0x5555562e2160, 
    handle=0x555556632af0) at /ws/src/ros2/rclcpp/rclcpp/include/rclcpp/executors/scheduler.hpp:186
        l = {_M_device = @0x5555562e2168}
#8  0x00007ffff79a6131 in rclcpp::executors::CBGScheduler::CallbackGroupHandle::check_move_to_ready (this=0x555556632af0)
    at /ws/src/ros2/rclcpp/rclcpp/include/rclcpp/executors/scheduler.hpp:124
No locals.
#9  0x00007ffff79aee46 in operator()(std::function<void()>) const (__closure=0x555556632d80, executed_callback=...)
    at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/first_in_first_out_scheduler.cpp:47
        l = {_M_device = @0x555556632b00}
        this = 0x555556632af0
        weak_ptr = warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#1}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#1}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::weak_ptr<rclcpp::TimerBase> (use count 1, weak count 3) = {get() = 0x5555567939e0}
#10 0x00007ffff79b13ca in std::__invoke_impl<void, rclcpp::executors::FirstInFirstOutCallbackGroupHandle::get_ready_callback_for_entity(const rclcpp::TimerBase::WeakPtr&)::<lambda(std::function<void()>)>&, std::function<void()> >(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/13/bits/invoke.h:61
No locals.
#11 0x00007ffff79b0b1b in std::__invoke_r<void, rclcpp::executors::FirstInFirstOutCallbackGroupHandle::get_ready_callback_for_entity(const rclcpp::TimerBase::WeakPtr&)::<lambda(std::function<void()>)>&, std::function<void()> >(struct {...} &) (
    __fn=...) at /usr/include/c++/13/bits/invoke.h:111
No locals.
#12 0x00007ffff79b03cc in std::_Function_handler<void(std::function<void()>), rclcpp::executors::FirstInFirstOutCallbackGroupHandle::get_ready_callback_for_entity(const rclcpp::TimerBase::WeakPtr&)::<lambda(std::function<void()>)> >::_M_invoke(const std::_Any_data &, std::function<void()> &&) (__functor=..., __args#0=...) at /usr/include/c++/13/bits/std_function.h:290
No locals.
#13 0x00007ffff7978c69 in std::function<void (std::function<void ()>)>::operator()(std::function<void ()>) const (
    this=0x555556631ee8, __args#0=...) at /usr/include/c++/13/bits/std_function.h:591
No locals.
#14 0x00007ffff797400b in rclcpp::executors::TimerQueue::call_ready_timer_callbacks (this=0x5555564d31f0)
    at /ws/src/ros2/rclcpp/rclcpp/include/rclcpp/executors/timer_manager.hpp:309
        time_until_call = -164707
        rcl_timer_ref = 0x55555662eff0
        ret = 0
#15 0x00007ffff797439e in rclcpp::executors::TimerQueue::timer_thread (this=0x5555564d31f0)
    at /ws/src/ros2/rclcpp/rclcpp/include/rclcpp/executors/timer_manager.hpp:345
        l = {_M_device = @0x5555564d3268}
        next_wakeup_time = std::chrono::duration = { 1767131002021565499ns }
#16 0x00007ffff7972e29 in rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const--Type <RET> for more, q to quit, c to continue without paging--
&)::{lambda()#1}::operator()() const (__closure=0x55555611d538)
    at /ws/src/ros2/rclcpp/rclcpp/include/rclcpp/executors/timer_manager.hpp:63
        this = 0x5555564d31f0
#17 0x00007ffff79a2ba6 in std::__invoke_impl<void, rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}>(std::__invoke_other, rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}&&) (__f=...) at /usr/include/c++/13/bits/invoke.h:61
No locals.
#18 0x00007ffff79a2b61 in std::__invoke<rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}>(rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}&&) (__fn=...) at /usr/include/c++/13/bits/invoke.h:96
No locals.
#19 0x00007ffff79a2b02 in std::thread::_Invoker<std::tuple<rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x55555611d538)
    at /usr/include/c++/13/bits/std_thread.h:292
No locals.
#20 0x00007ffff79a2ad2 in std::thread::_Invoker<std::tuple<rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}> >::operator()() (this=0x55555611d538)
    at /usr/include/c++/13/bits/std_thread.h:299
No locals.
#21 0x00007ffff79a2ab2 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<rclcpp::executors::TimerQueue::TimerQueue(rcl_clock_type_e, std::shared_ptr<rclcpp::Context> const&)::{lambda()#1}> > >::_M_run() (this=0x55555611d530)
    at /usr/include/c++/13/bits/std_thread.h:244
No locals.
#22 0x00007ffff6c6edb4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
No symbol table info available.
#23 0x00007ffff6923aa4 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:447
        ret = <optimized out>
        pd = <optimized out>
        out = <optimized out>
        unwind_buf = {cancel_jmp_buf = {{jmp_buf = {140736917911232, -4982769740560514913, 140736917911232, -2208, 0, 
                140737488324976, -4982769740514377569, -4982683742951096161}, mask_was_saved = 0}}, priv = {pad = {0x0, 
              0x0, 0x0, 0x0}, data = {prev = 0x0, cleanup = 0x0, canceltype = 0}}}
        not_first_call = <optimized out>
#24 0x00007ffff69b0c6c in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```
</details>

main thread
`FirstInFirstOutScheduler::get_next_ready_entity` acquires `ready_callback_groups_mutex`
then `FirstInFirstOutCallbackGroupHandle::get_next_ready_entity` tries to acquire `ready_mutex`


<details>
  <summary>GDB backtrace: Main thread</summary>

```cpp
(gdb) thread 1
[Switching to thread 1 (Thread 0x7ffff653ff40 (LWP 46656))]
#0  futex_wait (private=0, expected=2, futex_word=0x555556632b00) at ../sysdeps/nptl/futex-internal.h:146
146     in ../sysdeps/nptl/futex-internal.h
(gdb) bt full
#0  futex_wait (private=0, expected=2, futex_word=0x555556632b00) at ../sysdeps/nptl/futex-internal.h:146
        __ret = -512
        err = <optimized out>
        err = <optimized out>
        __ret = <optimized out>
        resultvar = <optimized out>
        __arg4 = <optimized out>
        __arg3 = <optimized out>
        __arg2 = <optimized out>
        __arg1 = <optimized out>
        _a4 = <optimized out>
        _a3 = <optimized out>
        _a2 = <optimized out>
        _a1 = <optimized out>
#1  __GI___lll_lock_wait (futex=futex@entry=0x555556632b00, private=0) at ./nptl/lowlevellock.c:49
No locals.
#2  0x00007ffff6927101 in lll_mutex_lock_optimized (mutex=0x555556632b00) at ./nptl/pthread_mutex_lock.c:48
        __futex = 0x555556632b00
        private = <optimized out>
        private = <optimized out>
        __futex = <optimized out>
#3  ___pthread_mutex_lock (mutex=0x555556632b00) at ./nptl/pthread_mutex_lock.c:93
        type = <optimized out>
        __PRETTY_FUNCTION__ = "___pthread_mutex_lock"
        id = <optimized out>
#4  0x0000555555ce8b75 in __gthread_mutex_lock (__mutex=0x555556632b00)
    at /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:749
No locals.
#5  0x0000555555cec88c in std::mutex::lock (this=0x555556632b00) at /usr/include/c++/13/bits/std_mutex.h:113
        __e = 21845
#6  0x0000555555cf44a2 in std::lock_guard<std::mutex>::lock_guard (this=0x7fffffff8280, __m=...)
    at /usr/include/c++/13/bits/std_mutex.h:249
No locals.
#7  0x00007ffff79af907 in rclcpp::executors::FirstInFirstOutCallbackGroupHandle::get_next_ready_entity (
    this=0x555556632af0, max_id=46) at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/first_in_first_out_scheduler.cpp:146
        l = {_M_device = @0x555556632b00}
#8  0x00007ffff79afcd1 in rclcpp::executors::FirstInFirstOutScheduler::get_next_ready_entity (this=0x5555562e2160, 
    max_id=46) at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/first_in_first_out_scheduler.cpp:216
        ready_cbg = 0x555556632af0
        ret = std::optional = {[contained value] = {
            execute_function = {<std::_Maybe_unary_or_binary_function<void>> = {<No data fields>}, <std::_Function_base> = {static _M_max_size = 16, static _M_max_align = 8, _M_functor = {_M_unused = {_M_object = 0x5555567d5ad0, 
                    _M_const_object = 0x5555567d5ad0, _M_function_pointer = 0x5555567d5ad0, 
                    _M_member_pointer = (void (std::_Undefined_class::*)(std::_Undefined_class * const)) 0x5555567d5ad0, this adjustment 140737488327696}, _M_pod_data = "\320Z}VUU\000\000\020\224\377\377\377\177\000"}, 
                _M_manager = 0x7fffffff83c0}, 
              _M_invoker = 0x7ffff7984a6a <std::unique_ptr<rclcpp::executors::CBGScheduler, std::default_delete<rclcpp::executors::CBGScheduler> >::get() const+28>}, callback_handle = 0x5555560c66f0}}
        it = 0x555556632af0
        l = {_M_device = @0x5555562e2168}
#9  0x00007ffff7966ef0 in rclcpp::executors::EventsExecutor::execute_previous_ready_executables_until (
    this=0x7fffffff8e60, stop_time=std::chrono::_V2::steady_clock time_point = { 3100388912249ns })
    at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/events_executor.cpp:211
        ready_entity = std::optional = {[contained value] = {
            execute_function = {<std::_Maybe_unary_or_binary_function<void>> = {<No data fields>}, <std::_Function_base> = {static _M_max_size = 16, static _M_max_align = 8, _M_functor = {_M_unused = {_M_object = 0x7fffffff84b8, 
                    _M_const_object = 0x7fffffff84b8, _M_function_pointer = 0x7fffffff84b8, 
                    _M_member_pointer = (void (std::_Undefined_class::*)(std::_Undefined_class * const)) 0x7fffffff84b8, this adjustment 140737488323800}, _M_pod_data = "\270\204\377\377\377\177\000\000؄\377\377\377\177\000"}, 
                _M_manager = 0x7fffffff8450}, 
              _M_invoker = 0x555555ceda20 <std::__shared_ptr<rclcpp::Context, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()+32>}, callback_handle = 0x2d1dcfbd5f9}}
        found_work = false
        last_ready_id = 46
#10 0x00007ffff796a4e6 in rclcpp::executors::EventsExecutor::collect_and_execute_ready_events (this=0x7fffffff8e60, 
    max_duration=std::chrono::duration = { 10000000ns }, recollect_if_no_work_available=true)
    at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/events_executor.cpp:482
        scope_exit_471 = {callable_ = {__this = 0x7fffffff8e60}, cancelled_ = false}
        start = std::chrono::_V2::steady_clock time_point = { 3100378912249ns }
--Type <RET> for more, q to quit, c to continue without paging--
        end_time = std::chrono::_V2::steady_clock time_point = { 3100388912249ns }
        cur_time = std::chrono::_V2::steady_clock time_point = { 3100378912249ns }
        had_work = false
#11 0x00007ffff796a1d5 in rclcpp::executors::EventsExecutor::spin_all (this=0x7fffffff8e60, 
    max_duration=std::chrono::duration = { 10000000ns })
    at /ws/src/ros2/rclcpp/rclcpp/src/rclcpp/executors/events_executor.cpp:459
        __func__ = "spin_all"
#12 0x0000555555d63f6f in TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody (
    this=0x5555565938b0) at /ws/src/ros2/rclcpp/rclcpp/test/rclcpp/executors/test_executors.cpp:986
        cur_time = std::chrono::_V2::steady_clock time_point = { 3100378912177ns }
        executor = {<rclcpp::Executor> = {
            _vptr.Executor = 0x7ffff7dc9278 <vtable for rclcpp::executors::EventsExecutor+16>, 
            spinning = std::atomic<bool> = { false }, 
            interrupt_guard_condition_ = std::shared_ptr<rclcpp::GuardCondition> (use count 3, weak count 0) = {
              get() = 0x5555564bc170}, 
            shutdown_guard_condition_ = std::shared_ptr<rclcpp::GuardCondition> (use count 3, weak count 1) = {
              get() = 0x5555567e2700}, mutex_ = {<std::__mutex_base> = {_M_mutex = {__data = {__lock = 0, __count = 0, 
                    __owner = 0, __nusers = 0, __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, 
                      __next = 0x0}}, __size = '\000' <repeats 39 times>, __align = 0}}, <No data fields>}, 
            context_ = std::shared_ptr<rclcpp::Context> (use count 11, weak count 4) = {get() = 0x5555560c66b0}, 
            notify_waitable_ = std::shared_ptr<rclcpp::executors::ExecutorNotifyWaitable> (use count 2, weak count 0) = {
              get() = 0x5555567e2880}, entities_need_rebuild_ = std::atomic<bool> = { true }, collector_ = {
              mutex_ = {<std::__mutex_base> = {_M_mutex = {__data = {__lock = 0, __count = 0, __owner = 0, __nusers = 0, 
                      __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, 
                    __size = '\000' <repeats 39 times>, __align = 0}}, <No data fields>}, 
              manually_added_groups_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, automatically_added_groups_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, 
              weak_nodes_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, weak_nodes_to_guard_conditions_ = std::map with 0 elements, 
              weak_groups_to_guard_conditions_ = std::map with 0 elements, pending_added_nodes_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'

              , pending_removed_nodes_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, 
              pending_manually_added_groups_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, 
              pending_manually_removed_groups_ = std::set with 0 elementsPython Exception <class 'AttributeError'>: 'NoneType' object has no attribute 'pointer'
, 
              notify_waitable_ = std::shared_ptr<rclcpp::executors::ExecutorNotifyWaitable> (use count 2, weak count 0) = {
                get() = 0x5555567e2880}}, 
            wait_set_ = {<rclcpp::wait_set_policies::SequentialSynchronization> = {<rclcpp::wait_set_policies::detail::SynchronizationPolicyCommon> = {<No data fields>}, <No data fields>}, <rclcpp::wait_set_policies::DynamicStorage> = {<rclcpp::wait_set_policies::detail::StoragePolicyCommon<false>> = {rcl_wait_set_ = {subscriptions = 0x0, size_of_subscriptions = 0, 
                    guard_conditions = 0x0, size_of_guard_conditions = 0, timers = 0x0, size_of_timers = 0, clients = 0x0, 
                    size_of_clients = 0, services = 0x0, size_of_services = 0, events = 0x0, size_of_events = 0, 
                    impl = 0x5555567e2b10}, context_ = std::shared_ptr<rclcpp::Context> (use count 11, weak count 4) = {
                    get() = 0x5555560c66b0}, needs_pruning_ = false, needs_resize_ = true}, 
                ownership_reference_counter_ = 0, subscriptions_ = std::vector of length 0, capacity 0, 
                shared_subscriptions_ = std::vector of length 0, capacity 0, 
                guard_conditions_ = std::vector of length 0, capacity 0, 
                shared_guard_conditions_ = std::vector of length 0, capacity 0, 
                timers_ = std::vector of length 0, capacity 0, shared_timers_ = std::vector of length 0, capacity 0, 
                clients_ = std::vector of length 0, capacity 0, shared_clients_ = std::vector of length 0, capacity 0, 
                services_ = std::vector of length 0, capacity 0, shared_services_ = std::vector of length 0, capacity 0, 
                waitables_ = std::vector of length 1, capacity 1 = {{
                    waitable = std::weak_ptr<rclcpp::Waitable> (use count 1, weak count 2) = {get() = 0x5555567e2d60}, 
                    associated_entity = std::weak_ptr<void> (empty) = {get() = 0x0}}}, 
                shared_waitables_ = std::vector of length 0, capacity 0}, wait_result_holding_ = false, 
              wait_result_dirty_ = false}, wait_result_ = std::optional [no contained value], current_collection_ = {
              timers = {<std::unordered_map<rcl_timer_s const*, rclcpp::executors::CollectionEntry<rclcpp::TimerBase>, std::hash<rcl_timer_s const*>, std::equal_to<rcl_timer_s const*>, std::allocator<std::pair<rcl_timer_s const* const, rclcpp::executors::CollectionEntry<rclcpp::TimerBase> > > >> = std::unordered_map with 0 elements, <No data fields>}, 
              subscriptions = {<std::unordered_map<rcl_subscription_s const*, rclcpp::executors::CollectionEntry<rclcpp::SubscriptionBase>, std::hash<rcl_subscription_s const*>, std::equal_to<rcl_subscription_s const*>, std::allocator<std::pair<rcl_subscription_s const* const, rclcpp::executors::CollectionEntry<rclcpp::SubscriptionBase> > > >> = std::unordered_map with 0 elements, <No data fields>}, 
              clients = {<std::unordered_map<rcl_client_s const*, rclcpp::executors::CollectionEntry<rclcpp::ClientBase>, std::hash<rcl_client_s const*>, std::equal_to<rcl_client_s const*>, std::allocator<std::pair<rcl_client_s const* const, rclcpp::executors::CollectionEntry<rclcpp::ClientBase> > > >> = std::unordered_map with 0 elements, <No data fields>}, 
              services = {<std::unordered_map<rcl_service_s const*, rclcpp::executors::CollectionEntry<rclcpp::ServiceBase>, std::hash<rcl_service_s const*>, std::equal_to<rcl_service_s const*>, std::allocator<std::pair<rcl_service_s const* const, rclcpp::executors::CollectionEntry<rclcpp::ServiceBase> > > >> = std::unordered_map with 0 elements, <No data fields>}, 
              guard_conditions = {<std::unordered_map<rcl_guard_condition_s const*, rclcpp::executors::CollectionEntry<rclcpp::GuardCondition>, std::hash<rcl_guard_condition_s const*>, std::equal_to<rcl_guard_condition_s const*>, std::allocator<std::pair<rcl_guard_condition_s const* const, rclcpp::executors::CollectionEntry<rclcpp::GuardCondition> > > >> = std::unordered_map with 0 elements, <No data fields>}, 
--Type <RET> for more, q to quit, c to continue without paging--
              waitables = {<std::unordered_map<rclcpp::Waitable const*, rclcpp::executors::CollectionEntry<rclcpp::Waitable>, std::hash<rclcpp::Waitable const*>, std::equal_to<rclcpp::Waitable const*>, std::allocator<std::pair<rclcpp::Waitable const* const, rclcpp::executors::CollectionEntry<rclcpp::Waitable> > > >> = std::unordered_map with 1 element = {
                  [0x5555567e2d60] = {entity = std::weak_ptr<rclcpp::Waitable> (use count 1, weak count 2) = {
                      get() = 0x5555567e2d60}, callback_group = std::weak_ptr<rclcpp::CallbackGroup> (empty) = {
                      get() = 0x0}}}, <No data fields>}}, 
            current_notify_waitable_ = std::shared_ptr<rclcpp::executors::ExecutorNotifyWaitable> (use count 1, weak count 2) = {get() = 0x5555567e2d60}, shutdown_callback_handle_ = {
              callback = std::weak_ptr<std::function<void()>> (use count 1, weak count 1) = {get() = 0x5555567e2c80}}, 
            impl_ = std::unique_ptr<rclcpp::ExecutorImplementation> = {get() = 0x5555567e2c10}}, 
          scheduler = std::unique_ptr<rclcpp::executors::CBGScheduler> = {get() = 0x5555562e2160}, rcl_polling_thread = {
            _M_id = {_M_thread = 0}}, added_callback_groups_mutex_ = {<std::__mutex_base> = {_M_mutex = {__data = {
                  __lock = 0, __count = 0, __owner = 0, __nusers = 0, __kind = 0, __spins = 0, __elision = 0, __list = {
                    __prev = 0x0, __next = 0x0}}, __size = '\000' <repeats 39 times>, __align = 0}}, <No data fields>}, 
          added_callback_groups = std::vector of length 0, capacity 0, added_nodes_mutex_ = {<std::__mutex_base> = {
              _M_mutex = {__data = {__lock = 0, __count = 0, __owner = 0, __nusers = 0, __kind = 0, __spins = 0, 
                  __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, __size = '\000' <repeats 39 times>, 
                __align = 0}}, <No data fields>}, added_nodes = std::vector of length 2, capacity 2 = {
            std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface> (expired, weak count 1) = {get() = 0x55555611dc40}, 
            std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface> (use count 21, weak count 2) = {
              get() = 0x55555611dd20}}, callback_groups_mutex = {<std::__mutex_base> = {_M_mutex = {__data = {__lock = 0, 
                  __count = 0, __owner = 0, __nusers = 0, __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, 
                    __next = 0x0}}, __size = '\000' <repeats 39 times>, __align = 0}}, <No data fields>}, 
          callback_groups = std::vector of length 2, capacity 6 = {{
              callback_group = std::weak_ptr<rclcpp::CallbackGroup> (expired, weak count 2) = {get() = 0x55555659be30}, 
              registered_entities = std::unique_ptr<rclcpp::executors::RegisteredEntityCache> = {get() = 0x55555676ead0}}, 
            {callback_group = std::weak_ptr<rclcpp::CallbackGroup> (use count 1, weak count 3) = {get() = 0x555556797980}, 
              registered_entities = std::unique_ptr<rclcpp::executors::RegisteredEntityCache> = {
                get() = 0x5555565d8240}}}, number_of_threads_ = 32, next_exec_timeout_ = std::chrono::duration = { -1ns }, 
          needs_callback_group_resync = std::atomic<bool> = { false }, spinning = std::atomic<bool> = { true }, 
          interrupt_guard_condition_ = std::shared_ptr<rclcpp::GuardCondition> (use count 2, weak count 0) = {
            get() = 0x55555611d2d0}, 
          shutdown_guard_condition_ = std::shared_ptr<rclcpp::GuardCondition> (use count 2, weak count 1) = {
            get() = 0x55555611d3a0}, shutdown_callback_handle_ = {
            callback = std::weak_ptr<std::function<void()>> (use count 1, weak count 1) = {get() = 0x55555611db40}}, 
          context_ = std::shared_ptr<rclcpp::Context> (use count 11, weak count 4) = {get() = 0x5555560c66b0}, 
          timer_manager = std::unique_ptr<rclcpp::executors::TimerManager> = {get() = 0x5555564d31f0}, 
          global_executable_cache = std::unique_ptr<rclcpp::executors::GlobalWeakExecutableCache> = {
            get() = 0x55555611daf0}, 
          nodes_executable_cache = std::unique_ptr<rclcpp::executors::GlobalWeakExecutableCache> = {
            get() = 0x55555611db10}}
        node1 = std::shared_ptr<rclcpp::Node> (empty) = {get() = 0x0}
        node2 = std::shared_ptr<rclcpp::Node> (use count 1, weak count 1) = {get() = 0x5555568573d0}
        timer1_works = true
        timer2_works = false
        timer1 = warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#1}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#1}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::<lambda()>, 0>> (use count 1, weak count 3) = {get() = 0x5555567939e0}
        timer2 = warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#2}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::{lambda()#2}, (void*)0>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr<rclcpp::GenericTimer<TestExecutors_dropSomeNodeWithTimer_Test<rclcpp::executors::EventsExecutor>::TestBody()::<lambda()>, 0>> (use count 1, weak count 3) = {get() = 0x5555567a6610}
        max_end_time = std::chrono::_V2::steady_clock time_point = { 3100471162889ns }
#13 0x0000555555f0d32b in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (
    object=0x5555565938b0, method=&virtual testing::Test::TestBody(), location=0x555555f555d3 "the test body")
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2612
No locals.
#14 0x0000555555f0544d in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (
    object=0x5555565938b0, method=&virtual testing::Test::TestBody(), location=0x555555f555d3 "the test body")
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2648
No locals.
#15 0x0000555555edda94 in testing::Test::Run (this=0x5555565938b0)
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2687
        impl = 0x555556098cf0
#16 0x0000555555ede665 in testing::TestInfo::Run (this=0x5555560a72d0)
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2836
        repeater = 0x55555606de70
        impl = 0x555556098cf0
        timer = {start_ = std::chrono::_V2::steady_clock time_point = { 3100331435789ns }}
        test = 0x5555565938b0
#17 0x0000555555edf0de in testing::TestSuite::Run (this=0x555556099620)
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:3015
--Type <RET> for more, q to quit, c to continue without paging--
        i = 21
        impl = 0x555556098cf0
        repeater = 0x55555606de70
        skip_all = false
        timer = {start_ = std::chrono::_V2::steady_clock time_point = { 3097267163265ns }}
#18 0x0000555555ef0262 in testing::internal::UnitTestImpl::RunAllTests (this=0x555556098cf0)
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5920
        test_index = 2
        timer = {start_ = std::chrono::_V2::steady_clock time_point = { 3090598155029ns }}
        i = 0
        gtest_is_initialized_before_run_all_tests = true
        in_subprocess_for_death_test = false
        should_shard = false
        has_tests_to_run = true
        failed = false
        repeater = 0x55555606de70
        repeat = 1
        gtest_repeat_forever = false
        recreate_environments_when_repeating = false
#19 0x0000555555f0e64a in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>
    (object=0x555556098cf0, 
    method=(bool (testing::internal::UnitTestImpl::*)(class testing::internal::UnitTestImpl * const)) 0x555555eefe2e <testing::internal::UnitTestImpl::RunAllTests()>, location=0x555555f56020 "auxiliary test code (environments or event listeners)")
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2612
No locals.
#20 0x0000555555f069a9 in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (
    object=0x555556098cf0, 
    method=(bool (testing::internal::UnitTestImpl::*)(class testing::internal::UnitTestImpl * const)) 0x555555eefe2e <testing::internal::UnitTestImpl::RunAllTests()>, location=0x555555f56020 "auxiliary test code (environments or event listeners)")
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2648
No locals.
#21 0x0000555555eee695 in testing::UnitTest::Run (this=0x55555604d500 <testing::UnitTest::GetInstance()::instance>)
    at /ws/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5484
        in_death_test_child_process = false
        premature_exit_file = {premature_exit_filepath_ = ""}
#22 0x0000555555ec8e90 in RUN_ALL_TESTS () at /ws/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2317
No locals.
#23 0x0000555555ec8e78 in main (argc=1, argv=0x7fffffff9af8)
    at /ws/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:64
```
</details>

This PR provides one possible approach to solve the lock order inversion by temporarily unlocking `ready_callback_groups_mutex` when querying the callback group itself for the next ready entity, so that only `ready_mutex` is acquired during that time and we avoid holding onto `ready_callback_groups_mutex` when the locks may be acquired in an inverse order if a timer is triggered. I've also added some missing tests from upstream `test_executors`.

I'm open to other ideas or alternatives to fix the inverted lock scenario, but this seemed like the easiest approach.