### PR TITLE
Fix API breaks from removal of shared_ptr copies in rclcpp

### DIFF
--- a/include/cm_executors/events_cbg_executor.hpp
+++ b/include/cm_executors/events_cbg_executor.hpp
@@ -68,8 +68,8 @@ public:
   RCLCPP_PUBLIC
   virtual void
   add_callback_group(
-    rclcpp::CallbackGroup::SharedPtr group_ptr,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+    const rclcpp::CallbackGroup::SharedPtr & group_ptr,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_ptr,
     bool notify = true);
 
   RCLCPP_PUBLIC
@@ -79,12 +79,14 @@ public:
   RCLCPP_PUBLIC
   virtual void
   remove_callback_group(
-    rclcpp::CallbackGroup::SharedPtr group_ptr,
+    const rclcpp::CallbackGroup::SharedPtr & group_ptr,
     bool notify = true);
 
   RCLCPP_PUBLIC
   virtual void
-  add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
+  add_node(
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_ptr,
+    bool notify = true);
 
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   /**
@@ -92,11 +94,13 @@ public:
    */
   RCLCPP_PUBLIC
   virtual void
-  add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+  add_node(const std::shared_ptr<rclcpp::Node> & node_ptr, bool notify = true);
 
   RCLCPP_PUBLIC
   virtual void
-  remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify = true);
+  remove_node(
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_ptr,
+    bool notify = true);
 
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   /**
@@ -104,11 +108,11 @@ public:
    */
   RCLCPP_PUBLIC
   virtual void
-  remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
+  remove_node(const std::shared_ptr<rclcpp::Node> & node_ptr, bool notify = true);
 
 
   // add a callback group to the executor, not bound to any node
-  void add_callback_group_only(rclcpp::CallbackGroup::SharedPtr group_ptr);
+  void add_callback_group_only(const rclcpp::CallbackGroup::SharedPtr & group_ptr);
 
   /**
    * \sa rclcpp::Executor:spin() for more details

--- a/src/events_cbg_executor.cpp
+++ b/src/events_cbg_executor.cpp
@@ -552,8 +552,8 @@ void EventsCBGExecutor::spin(std::function<void(const std::exception & e)> excep
 
 void
 EventsCBGExecutor::add_callback_group(
-  rclcpp::CallbackGroup::SharedPtr group_ptr,
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr /*node_ptr*/,
+  const rclcpp::CallbackGroup::SharedPtr & group_ptr,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & /*node_ptr*/,
   bool notify)
 {
   {
@@ -635,7 +635,7 @@ const
 
 void
 EventsCBGExecutor::remove_callback_group(
-  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  const rclcpp::CallbackGroup::SharedPtr & group_ptr,
   bool notify)
 {
   bool found = false;
@@ -681,7 +681,7 @@ EventsCBGExecutor::remove_callback_group(
 
 void
 EventsCBGExecutor::add_node(
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_ptr,
   bool notify)
 {
   // If the node already has an executor
@@ -707,14 +707,14 @@ EventsCBGExecutor::add_node(
 }
 
 void
-EventsCBGExecutor::add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
+EventsCBGExecutor::add_node(const std::shared_ptr<rclcpp::Node> & node_ptr, bool notify)
 {
   add_node(node_ptr->get_node_base_interface(), notify);
 }
 
 void
 EventsCBGExecutor::remove_node(
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node_ptr,
   bool notify)
 {
   {
@@ -731,7 +731,7 @@ EventsCBGExecutor::remove_node(
   }
 
   node_ptr->for_each_callback_group(
-    [this](rclcpp::CallbackGroup::SharedPtr cbg)
+    [this](const rclcpp::CallbackGroup::SharedPtr & cbg)
     {
       unregister_event_callbacks(cbg);
     }
@@ -755,13 +755,13 @@ EventsCBGExecutor::remove_node(
 }
 
 void
-EventsCBGExecutor::remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
+EventsCBGExecutor::remove_node(const std::shared_ptr<rclcpp::Node> & node_ptr, bool notify)
 {
   remove_node(node_ptr->get_node_base_interface(), notify);
 }
 
 // add a callback group to the executor, not bound to any node
-void EventsCBGExecutor::add_callback_group_only(rclcpp::CallbackGroup::SharedPtr group_ptr)
+void EventsCBGExecutor::add_callback_group_only(const rclcpp::CallbackGroup::SharedPtr & group_ptr)
 {
   add_callback_group(group_ptr, nullptr, true);
 }


### PR DESCRIPTION
The changes introduced in https://github.com/ros2/rclcpp/pull/3079 resulted in a regression when trying to use alongside the `EventsCBGExecutor`, where none of the nodes end up doing any work. This PR changes the function signatures of `add_node`, `remove_node`, `add_callback_group`, `remove_callback_group`, and `add_callback_group_only` to use const references, so as to stay in sync with the recent rclcpp-side changes. 