### PR TITLE
Avoid shared_ptr::unique in timer manager

### DIFF
--- a/include/cm_executors/timer_manager.hpp
+++ b/include/cm_executors/timer_manager.hpp
@@ -307,7 +307,7 @@ private:
    */
   bool remove_if_dropped(const TimerData * timer_data)
   {
-    if (timer_data->rcl_ref.unique()) {
+    if (timer_data->rcl_ref.use_count() == 1) {
       // clear on reset callback
       if(rcl_timer_set_on_reset_callback(timer_data->rcl_ref.get(), nullptr,
           nullptr) != RCL_RET_OK)


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-cm-executors.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: std::shared_ptr::unique() is no longer available in C++20. The existing logic only needs to know whether the timer reference is the sole owner, and use_count() == 1 preserves that behavior with current C++ standards.